### PR TITLE
Avoid eventloop restart if listen_address or port didn't changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ addons:
   postgresql: "9.6"
 before_install:
   - sudo apt-get update
-  - sudo apt-get install postgresql-server-dev-9.6 libevent-dev
-  - pip install cpp-coveralls
+  - sudo apt-get install -y postgresql-server-dev-9.6 libevent-dev
+  - sudo pip install --upgrade cpp-coveralls
 script:
   - |
     set -e
@@ -25,9 +25,10 @@ script:
     psql -h localhost -p 5440 -d postgres -c "select pg_advisory_lock(1), pg_sleep(5)" &
     ( time pg_basebackup -D test_cluster_backup -c fast -X stream -h localhost -p 5440 -r 2M )&
     sleep 1
+    echo "bg_mon.port = 8081" >> test_cluster/postgresql.conf
     pg_ctl -D test_cluster reload
-    curl http://localhost:8080/ui > /dev/null
-    ( for a in {1..10}; do curl http://localhost:8080 && echo && sleep 1 && ps auxwwwf | grep postgres; done )&
+    curl http://localhost:8081/ui > /dev/null
+    ( for a in {1..10}; do curl http://localhost:8081 && echo && sleep 1 && ps auxwwwf | grep postgres; done )&
     wait
     pg_ctl -w -D test_cluster stop
     set +e

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-SHLIB_LINK += -levent -pthread
+SHLIB_LINK += -levent -levent_pthreads -pthread
 ifdef ENABLE_GCOV
 SHLIB_LINK += -lgcov --coverage
 endif

--- a/bg_mon.c
+++ b/bg_mon.c
@@ -270,9 +270,8 @@ bg_mon_main(Datum main_arg)
 	evthread_use_pthreads();
 
 restart:
-	bg_mon_listen_address = repalloc(bg_mon_listen_address,
-									 strlen(bg_mon_listen_address_guc) + 1);
-	if (!bg_mon_listen_address) {
+	FREE(bg_mon_listen_address);
+	if (!(bg_mon_listen_address = palloc(strlen(bg_mon_listen_address_guc) + 1))) {
 		elog(ERROR, "Couldn't allocate memory for bg_mon_listen_address: exiting");
 		return proc_exit(1);
 	}

--- a/bg_mon.c
+++ b/bg_mon.c
@@ -43,7 +43,7 @@ static volatile sig_atomic_t got_sigterm = false;
 /* GUC variables */
 static int bg_mon_naptime_guc = 1;
 static char *bg_mon_listen_address_guc;
-static char bg_mon_listen_address[NAME_MAX];
+static char *bg_mon_listen_address = NULL;
 static int bg_mon_port_guc = 8080;
 static int bg_mon_port = 8080;
 
@@ -270,6 +270,13 @@ bg_mon_main(Datum main_arg)
 	evthread_use_pthreads();
 
 restart:
+	bg_mon_listen_address = repalloc(bg_mon_listen_address,
+									 strlen(bg_mon_listen_address_guc) + 1);
+	if (!bg_mon_listen_address) {
+		elog(ERROR, "Couldn't allocate memory for bg_mon_listen_address: exiting");
+		return proc_exit(1);
+	}
+
 	strcpy(bg_mon_listen_address, bg_mon_listen_address_guc);
 	bg_mon_port = bg_mon_port_guc;
 

--- a/bg_mon.c
+++ b/bg_mon.c
@@ -4,6 +4,7 @@
 #include <event2/event.h>
 #include <event2/http.h>
 #include <event2/buffer.h>
+#include <event2/thread.h>
 
 #include "postgres.h"
 
@@ -40,8 +41,10 @@ static volatile sig_atomic_t got_sighup = false;
 static volatile sig_atomic_t got_sigterm = false;
 
 /* GUC variables */
-static int bg_mon_naptime = 1;
-static char *bg_mon_listen_address;
+static int bg_mon_naptime_guc = 1;
+static char *bg_mon_listen_address_guc;
+static char bg_mon_listen_address[NAME_MAX];
+static int bg_mon_port_guc = 8080;
 static int bg_mon_port = 8080;
 
 static pg_stat_list pg_stats_current;
@@ -264,8 +267,12 @@ bg_mon_main(Datum main_arg)
 	BackgroundWorkerInitializeConnection("postgres", NULL);
 
 	initialize_bg_mon();
+	evthread_use_pthreads();
 
 restart:
+	strcpy(bg_mon_listen_address, bg_mon_listen_address_guc);
+	bg_mon_port = bg_mon_port_guc;
+
 	if (!(base = event_base_new())) {
 		elog(ERROR, "Couldn't create an event_base: exiting");
 		return proc_exit(1);
@@ -299,7 +306,7 @@ restart:
 	while (!got_sigterm) {
 		double	naptime;
 
-		next_run.tv_sec += bg_mon_naptime; /* adjust wakeup target time */
+		next_run.tv_sec += bg_mon_naptime_guc; /* adjust wakeup target time */
 
 		gettimeofday(&current_time, &tz);
 
@@ -337,14 +344,20 @@ restart:
 			got_sighup = false;
 			ProcessConfigFile(PGC_SIGHUP);
 
-			pthread_cancel(thread);
-			pthread_join(thread, NULL);
+			if (strcmp(bg_mon_listen_address_guc, bg_mon_listen_address) != 0
+					|| bg_mon_port_guc != bg_mon_port) {
+				struct timeval delay = {0, 0};
 
-			pthread_mutex_destroy(&lock);
+				event_base_loopexit(base, &delay);
+//				pthread_cancel(thread);
+				pthread_join(thread, NULL);
 
-			evhttp_free(http);
-			event_base_free(base);
-			goto restart;
+				pthread_mutex_destroy(&lock);
+
+				evhttp_free(http);
+				event_base_free(base);
+				goto restart;
+			}
 		}
 
 		{
@@ -380,7 +393,7 @@ _PG_init(void)
 	DefineCustomIntVariable("bg_mon.naptime",
 							"Duration between each run (in seconds).",
 							NULL,
-							&bg_mon_naptime,
+							&bg_mon_naptime_guc,
 							1,
 							1,
 							10,
@@ -392,7 +405,7 @@ _PG_init(void)
 	DefineCustomStringVariable("bg_mon.listen_address",
 							"The IP address for the web server to listen on.",
 							NULL,
-							&bg_mon_listen_address,
+							&bg_mon_listen_address_guc,
 							"127.0.0.1",
 							PGC_SIGHUP,
 							0,
@@ -402,7 +415,7 @@ _PG_init(void)
 	DefineCustomIntVariable("bg_mon.port",
 							"Port number to bind the web server to.",
 							NULL,
-							&bg_mon_port,
+							&bg_mon_port_guc,
 							8080,
 							0,
 							65535,

--- a/disk_stats.c
+++ b/disk_stats.c
@@ -2,6 +2,7 @@
 #include <dirent.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
+#include <linux/limits.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <pthread.h>


### PR DESCRIPTION
+ use event_base_loopexit function to stop eventloop instead of pthread_cancel