### PR TITLE
Fix buffer overflow in get_pg_locks

### DIFF
--- a/bg_mon.c
+++ b/bg_mon.c
@@ -18,6 +18,7 @@
 /* these headers are used by this particular worker's code */
 #include "pgstat.h"
 #include "tcop/utility.h"
+#include "utils/memutils.h"
 #include "utils/timestamp.h"
 
 #include "net_stats.h"
@@ -360,6 +361,14 @@ bg_mon_main(Datum main_arg)
 	struct event_base *base;
 	struct evhttp *http;
 	struct evhttp_bound_socket *handle;
+
+#if PG_VERSION_NUM >= 90600
+	MemoryContext bg_mon_cxt = AllocSetContextCreate(TopMemoryContext, "BgMon", ALLOCSET_SMALL_SIZES);
+#else
+	MemoryContext bg_mon_cxt = AllocSetContextCreate(TopMemoryContext, "BgMon", ALLOCSET_SMALL_MINSIZE,
+													ALLOCSET_SMALL_INITSIZE, ALLOCSET_SMALL_MAXSIZE);
+#endif
+	MemoryContextSwitchTo(bg_mon_cxt);
 
 	pg_start_time = timestamptz_to_time_t(PgStartTime);
 


### PR DESCRIPTION
Every item returned by GetLockStatusData contains information about lock held mode (ExclusiveLock, AccessShareLock, RowExclusiveLock and so on).
pg_locks view reports all modes for the same object and pg_lock_status() was copied without a full understanding of how it supposed to work, what causes a buffer overflow.
In fact, we are not interested in all modes, but only about lock status. Taking into account that the given record can represent granted lock on a given object and at the same time it could be waiting for a more strict lock, we need to extend array size by 2.

In addition to above mentioned bugfix create a separate memory context for bg_mon itself and refactor a bit MemoryContextSwitchTo() calls