### PR TITLE
Special memory handling in the libevent thread 

### DIFF
--- a/bg_mon.c
+++ b/bg_mon.c
@@ -329,7 +329,7 @@ static void send_document_cb(struct evhttp_request *req, void *arg)
 	struct evbuffer *evb = evbuffer_new();
 
 	if (strncmp(uri, "/ui", 3)) {
-		if (!(err = system_stats_current.uptime == 0)) {
+		if (!(err = (system_stats_current.uptime == 0))) {
 			prepare_statistics_output(evb);
 			evhttp_add_header(evhttp_request_get_output_headers(req), "Content-Type", "application/json");
 		}

--- a/bg_mon.c
+++ b/bg_mon.c
@@ -21,6 +21,7 @@
 #include "utils/memutils.h"
 #include "utils/timestamp.h"
 
+#include "safety_funcs.h"
 #include "net_stats.h"
 #include "postgres_stats.h"
 #include "disk_stats.h"
@@ -391,37 +392,39 @@ bg_mon_main(Datum main_arg)
 
 	initialize_bg_mon();
 	evthread_use_pthreads();
+	event_set_mem_functions(malloc_fn, realloc_fn, free);
 
 restart:
 	FREE(bg_mon_listen_address);
-	if (!(bg_mon_listen_address = palloc(strlen(bg_mon_listen_address_guc) + 1))) {
-		elog(ERROR, "Couldn't allocate memory for bg_mon_listen_address: exiting");
-		return proc_exit(1);
-	}
-
+	bg_mon_listen_address = palloc(strlen(bg_mon_listen_address_guc) + 1);
 	strcpy(bg_mon_listen_address, bg_mon_listen_address_guc);
+
 	bg_mon_port = bg_mon_port_guc;
 
-	if (!(base = event_base_new())) {
-		elog(ERROR, "Couldn't create an event_base: exiting");
-		return proc_exit(1);
-	}
+	if (!(base = event_base_new()))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+				 errmsg("Couldn't create an event_base"),
+				 errdetail("event_base_new() returned NULL")));
 
 	/* Create a new evhttp object to handle requests. */
-	if (!(http = evhttp_new(base))) {
-		elog(ERROR, "couldn't create evhttp. Exiting.");
-		return proc_exit(1);
-	}
+	if (!(http = evhttp_new(base)))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+				 errmsg("Couldn't create an evhttp"),
+				 errdetail("evhttp_new() returned NULL")));
+
 
 	/* We want to accept arbitrary requests, so we need to set a "generic"
 	 * cb.  We can also add callbacks for specific paths. */
 	evhttp_set_gencb(http, send_document_cb, NULL);
 
 	/* Now we tell the evhttp what port to listen on */
-	if (!(handle = evhttp_bind_socket_with_handle(http, bg_mon_listen_address, bg_mon_port))) {
-		elog(ERROR, "couldn't bind to %s:%d. Exiting.", bg_mon_listen_address, bg_mon_port);
-		return proc_exit(1);
-	}
+	if (!(handle = evhttp_bind_socket_with_handle(http, bg_mon_listen_address, bg_mon_port)))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+				 errmsg("evhttp_bind_socket_with_handle() failed"),
+				 errdetail("couldn't bind to %s:%d", bg_mon_listen_address, bg_mon_port)));
 
 	pthread_mutex_init(&lock, NULL);
 

--- a/disk_stats.c
+++ b/disk_stats.c
@@ -426,7 +426,7 @@ static unsigned char find_or_add_device(device_stats *devices, const char *name)
 			goto resolve_hierarchy;
 		}
 
-	if (new_id == -1 && (new_id = devices->size++) >= devices->len)
+	if ((new_id = devices->size++) >= devices->len)
 		devices->values = repalloc(devices->values, sizeof(device_stat)*(devices->len = devices->size));
 
 	memset(devices->values + new_id, 0, sizeof(device_stat));

--- a/safety_funcs.c
+++ b/safety_funcs.c
@@ -1,0 +1,33 @@
+#include <stdlib.h>
+
+#include "safety_funcs.h"
+#include "storage/ipc.h"
+
+void exit_with_error_to_stderr(const char *filename, int lineno, const char *funcname, const char *fmt, ...)
+{
+	va_list	ap;
+
+	fprintf(stderr, "error occurred at %s:%d %s(): ",
+			filename ? filename : "(unknown file)", lineno, funcname ? funcname : "unknownFunc");
+
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	fflush(stderr);
+
+	proc_exit(1);
+}
+
+void *realloc_fn(void *ptr, size_t size)
+{
+	void *ret = realloc(ptr, size);
+
+	if (ret == NULL)
+		exit_with_error("Failed on request of size %zu in BgMon\n", size);
+
+	return ret;
+}
+
+void *malloc_fn(size_t size)
+{
+	return realloc_fn(NULL, size);
+}

--- a/safety_funcs.h
+++ b/safety_funcs.h
@@ -1,0 +1,14 @@
+#ifndef _SAFETY_FUNCS_H_
+#define _SAFETY_FUNCS_H_
+
+#include "postgres.h"
+
+#define exit_with_error(...) \
+	do { \
+		exit_with_error_to_stderr(__FILE__, __LINE__, PG_FUNCNAME_MACRO, __VA_ARGS__); \
+	} while (0)
+void exit_with_error_to_stderr(const char *filename, int lineno, const char *funcname, const char *fmt, ...) __attribute__((format(PG_PRINTF_ATTRIBUTE, 4, 5)));
+void *malloc_fn(size_t size);
+void *realloc_fn(void *ptr, size_t size);
+
+#endif /* _SAFETY_FUNCS_H_ */


### PR DESCRIPTION
From the main thread, we are using the usual memory contexts, which will exit the process if memory allocation/reallocation fails, while from the API thread we were mostly ignoring errors. This commit fixes it by setting custom memory management functions for libevent. These functions are simple wrappers over realloc() and will exit background worker on failure.