### PR TITLE
Collect and display cpu/memory statistics/limits from cgroups

### DIFF
--- a/bg_mon.c
+++ b/bg_mon.c
@@ -217,11 +217,11 @@ static void prepare_statistics_output(struct evbuffer *evb)
 	evbuffer_add_printf(evb, ", \"total\": %d, ", pg_stats_current.total_connections);
 	evbuffer_add_printf(evb, "\"active\": %d}, \"start_time\": %lu}, ", pg_stats_current.active_connections, pg_start_time);
 	evbuffer_add_printf(evb, "\"system_stats\": {\"uptime\": %d, \"load_average\": ", (int)(s.uptime / SC_CLK_TCK));
-	evbuffer_add_printf(evb, "[%4.6g, %4.6g, %4.6g], \"cpu\": ", la.run_1min, la.run_5min, la.run_15min);
-	evbuffer_add_printf(evb, "{\"user\": %2.1f, \"system\": %2.1f, \"idle\": ", c.utime_diff, c.stime_diff);
-	evbuffer_add_printf(evb, "%2.1f, \"iowait\": %2.1f}, \"ctxt\": %lu", c.idle_diff, c.iowait_diff, s.ctxt_diff);
-	evbuffer_add_printf(evb, ", \"processes\": {\"running\": %lu, \"blocked\": %lu}, ", s.procs_running, s.procs_blocked);
-	evbuffer_add_printf(evb, "\"memory\": {\"total\": %lu, \"free\": %lu, ", m.total, m.free);
+	evbuffer_add_printf(evb, "[%4.6g, %4.6g, %4.6g], \"cpu\": {\"user\": ", la.run_1min, la.run_5min, la.run_15min);
+	evbuffer_add_printf(evb, "%2.1f, \"nice\":  %2.1f, \"system\": %2.1f, ", c.utime_diff, c.ntime_diff, c.stime_diff);
+	evbuffer_add_printf(evb, "\"idle\": %2.1f, \"iowait\": %2.1f, \"steal\": %2.1f", c.idle_diff, c.iowait_diff, c.steal_diff);
+	evbuffer_add_printf(evb, "}, \"ctxt\": %lu, \"processes\": {\"running\": %lu, \"blocked\":", s.ctxt_diff, s.procs_running);
+	evbuffer_add_printf(evb, " %lu}, \"memory\": {\"total\": %lu, \"free\": %lu, ", s.procs_blocked, m.total, m.free);
 	evbuffer_add_printf(evb, "\"buffers\": %lu, \"cached\": %lu, \"dirty\": %lu", m.buffers, m.cached, m.dirty);
 
 	if (m.overcommit.memory == 2) {
@@ -229,10 +229,20 @@ static void prepare_statistics_output(struct evbuffer *evb)
 		evbuffer_add_printf(evb, "\"commit_limit\": %lu, \"committed_as\": %lu}", m.limit, m.as);
 	}
 
-	if (m.cgroup.available) {
+	if (m.cgroup.available || c.cgroup.available) {
 		cgroup_memory cm = m.cgroup;
-		evbuffer_add_printf(evb, ", \"cgroup\": {\"limit\": %lu, \"usage\": %lu", cm.limit, cm.usage);
-		evbuffer_add_printf(evb, ", \"rss\": %lu, \"cache\": %lu}", cm.rss, cm.cache);
+		cgroup_cpu cc = c.cgroup;
+		evbuffer_add_printf(evb, "}}, \"cgroup\": {");
+		if (cm.available) {
+			evbuffer_add_printf(evb, "\"memory\": {\"limit\": %lu, \"usage\": %lu", cm.limit, cm.usage);
+			evbuffer_add_printf(evb, ", \"rss\": %lu, \"cache\": %lu", cm.rss, cm.cache);
+			if (cc.available)
+				evbuffer_add_printf(evb, "}, ");
+		}
+		if (cc.available) {
+			evbuffer_add_printf(evb, "\"cpu\": {\"shares\": %llu, \"quota\": %lld", cc.shares, cc.quota);
+			evbuffer_add_printf(evb, ", \"user\": %2.1f, \"system\": %2.1f", cc.user_diff, cc.system_diff);
+		}
 	}
 
 	evbuffer_add_printf(evb, "}}, \"disk_stats\": {");

--- a/bg_mon.html
+++ b/bg_mon.html
@@ -384,6 +384,9 @@ function apply(data, ns) {
 			if (el != null) el.style.display = 'none';
 		} else
 			set_diskstats_values(data, 'wal');
+
+		var el = document.getElementById('cgroup_enabled');
+		if (el != null) el.style.display = 'cgroup' in data ? '' : 'none';
 	}
 
 	for (var key in data) {
@@ -402,6 +405,13 @@ function apply(data, ns) {
 					data[key]['used'] = data[key]['total'] - data[key]['free'];
 					if (data[key]['used'] > data[key]['cache'])
 						data[key]['used'] -= data[key]['cache'];
+
+					var overcommit_display = 'overcommit' in data[key] ? 'inline' : 'none';
+					var els = ['tmpl', 'enabled'];
+					for (var n = 0; n < els.length; ++n) {
+						var el = document.getElementById(ns_key + '.overcommit_' + els[n]);
+						if (el != null) el.style.display = overcommit_display;
+					}
 				}
 				for (var n in timeSeries[cn])
 					timeSeries[cn][n].append(t, data[key][n]);
@@ -476,9 +486,9 @@ Prism.languages.sql={comment:{pattern:/(^|[^\\])(?:\/\*[\s\S]*?\*\/|(?:--|\/\/|#
 				<span style="color: black">Total <b id="system_stats.memory.total"></b></span>
 				<span style="color: blue">Used <b id="system_stats.memory.used"></b></span>
 				<span style="color: green">Free <b id="system_stats.memory.free"></b></span>
-				<span style="color: orange">Buffers+Cache <b id="system_stats.memory.cache"></b></span><br>
+				<span style="color: orange">Buffers+Cache <b id="system_stats.memory.cache"></b></span><br id="system_stats.memory.overcommit_enabled">
 				<span style="color: black">Dirty <b id="system_stats.memory.dirty"></b></span>
-				<span style="color: black">Limit <b id="system_stats.memory.overcommit.commit_limit"></b> as <b id="system_stats.memory.overcommit.committed_as"></b></span>
+				<div id="system_stats.memory.overcommit_tmpl"><span style="color: black">Limit <b id="system_stats.memory.overcommit.commit_limit"></b> as <b id="system_stats.memory.overcommit.committed_as"></b></span></div>
 			</td>
 			<td>
 				<span style="color: black">data/<b id="io.data_dev"></b>:</span>
@@ -497,6 +507,20 @@ Prism.languages.sql={comment:{pattern:/(^|[^\\])(?:\/\*[\s\S]*?\*\/|(?:--|\/\/|#
 					<span style="color: black">Await: <b id="io.wal_await"></b></span>
 					<span style="color: black">%Util: <b id="io.wal_util"></b></span>
 				</div>
+			</td>
+		</tr>
+		<tr id="cgroup_enabled">
+			<td><b>cgroup Mem:</b>
+				<span>RSS: <b id="cgroup.memory.rss"></b></span>
+				<span>Cache: <b id="cgroup.memory.cache"></b></span>
+				<span>Usage: <b id="cgroup.memory.usage"></b></span>
+				<span>Limit: <b id="cgroup.memory.limit"></b></span>
+			</td>
+			<td><b>cgroup CPU:</b>
+				<span>User: <b id="cgroup.cpu.user"></b>%</span>
+				<span>System: <b id="cgroup.cpu.system"></b>%</span>
+				<span>Shares: <b id="cgroup.cpu.shares"></b></span>
+				<span>Quota: <b id="cgroup.cpu.quota"></b></span>
 			</td>
 		</tr>
 	</thead>

--- a/disk_stats.c
+++ b/disk_stats.c
@@ -41,6 +41,8 @@ static bool run_du;
 static unsigned long long data_du, wal_du;
 static unsigned int du_counter;
 
+char *cpu_cgroup_mount = NULL;
+char *cpuacct_cgroup_mount = NULL;
 char *memory_cgroup_mount = NULL;
 
 /******************************************************
@@ -154,6 +156,14 @@ static List *read_mounts()
 			m->me_dummy = is_dummy(me);
 			m->me_remote = is_remote(me);
 			mounts = lappend(mounts, m);
+			if (cpu_cgroup_mount == NULL
+					&& strcmp(me->mnt_type, "cgroup") == 0
+					&& hasmntopt(me, "cpu"))
+				cpu_cgroup_mount = pstrdup(me->mnt_dir);
+			if (cpuacct_cgroup_mount == NULL
+					&& strcmp(me->mnt_type, "cgroup") == 0
+					&& hasmntopt(me, "cpuacct"))
+				cpuacct_cgroup_mount = pstrdup(me->mnt_dir);
 			if (memory_cgroup_mount == NULL
 					&& strcmp(me->mnt_type, "cgroup") == 0
 					&& hasmntopt(me, "memory"))

--- a/system_stats.h
+++ b/system_stats.h
@@ -45,6 +45,18 @@ typedef struct {
 } meminfo;
 
 typedef struct {
+	bool available;
+	unsigned int online_cpus;
+	unsigned long long shares;
+	long long quota;
+	unsigned long long total;
+	unsigned long long system;
+	double system_diff;
+	unsigned long long user;
+	double user_diff;
+} cgroup_cpu;
+
+typedef struct {
 	int fields;
 	int cpu_count;
 	unsigned long long utime; // (1)
@@ -63,6 +75,7 @@ typedef struct {
 	double steal_diff;
 	unsigned long long uptime;
 	unsigned long long uptime0;
+	cgroup_cpu cgroup;
 } cpu_stat;
 
 typedef struct {


### PR DESCRIPTION
Cgroup CPU usage is not normalized to the number of CPU cores, i.e. 150% means that it consumes 1.5 CPU core.