### PR TITLE
Fix calculation of cgroup cpu stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ branches:
 before_install:
   - sudo service postgresql stop
   - sudo sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf
-  - if [ $PG = 13 ]; then sudo sed -i -e "s/main/main $PG/" /etc/apt/sources.list.d/pgdg*.list && sudo apt-get -qq update; fi
   - if ! sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install postgresql-$PG postgresql-server-dev-$PG libevent-dev pv brotli libbrotli1 libbrotli-dev; then echo; fi
   - sudo pip install --upgrade cpp-coveralls
 script:

--- a/system_stats.c
+++ b/system_stats.c
@@ -232,7 +232,7 @@ static cgroup_cpu read_cgroup_cpu_stats(void)
 		};
 
 		strcpy(cpuacct_cgroup + cpuacct_cgroup_len, "usage");
-		/* nanosecondsInMullisecond = 1000000.0, because we want to get millicores */
+		/* nanosecondsInMillisecond = 1000000.0, because we want to get millicores */
 		cc.total = read_ullong(cpuacct_cgroup) / 1000000.0;
 
 		strcpy(cpuacct_cgroup + cpuacct_cgroup_len, "usage_percpu");

--- a/system_stats.c
+++ b/system_stats.c
@@ -232,8 +232,8 @@ static cgroup_cpu read_cgroup_cpu_stats(void)
 		};
 
 		strcpy(cpuacct_cgroup + cpuacct_cgroup_len, "usage");
-		/* nanosecondsInSecond = 1000000000.0; */
-		cc.total = read_ullong(cpuacct_cgroup) / 1000000000.0 * SC_CLK_TCK;
+		/* nanosecondsInMullisecond = 1000000.0, because we want to get millicores */
+		cc.total = read_ullong(cpuacct_cgroup) / 1000000.0;
 
 		strcpy(cpuacct_cgroup + cpuacct_cgroup_len, "usage_percpu");
 		if ((csfd = fopen(cpuacct_cgroup, "r")) != NULL) {
@@ -332,7 +332,7 @@ static void diff_system_stats(system_stat *new_stats)
 
 	if (new_stats->cpu.cgroup.available) {
 		double total = new_stats->cpu.cgroup.online_cpus
-			* SP_VALUE_100(system_stats_old.cpu.cgroup.total, new_stats->cpu.cgroup.total, itv);
+			* S_VALUE(system_stats_old.cpu.cgroup.total, new_stats->cpu.cgroup.total, itv);
 		long long system_diff = new_stats->cpu.cgroup.system - system_stats_old.cpu.cgroup.system;
 		long long user_diff = new_stats->cpu.cgroup.user - system_stats_old.cpu.cgroup.user;
 		long long sum_diff = system_diff + user_diff;

--- a/test.sh
+++ b/test.sh
@@ -50,7 +50,6 @@ logging_collector = 'on'
 archive_mode = 'on'
 archive_command = 'true'
 max_wal_senders = 10
-wal_keep_segments = 100
 shared_preload_libraries = 'bg_mon'
 bg_mon.port = $(($bport+$1))" >> test_cluster$1/postgresql.conf
     if [ $version != "9.3" ] && [ $version != "9.4" ]; then


### PR DESCRIPTION
It was reported 10 times smaller than the real.