### PR TITLE
Flexible API for aggregated stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ If you did everything right, go to you browser and type following URLs to see re
 
 `http://<bg_mon.listen_address>:<bg_mon.port>/` -- expose collected statistics in a JSON format.
 
-`http://<bg_mon.listen_address>:<bg_mon.port>/X` -- get aggregated statistics from the bucket X, where X is between **0** and **history\_buckets**. The array with the current bucket might be not yet closed.
+`http://<bg_mon.listen_address>:<bg_mon.port>/X` -- get aggregated statistics from the bucket X, where X is between **0** and **history\_buckets**, **unixtime**, **time**, or **timestamp** in any format supported by postgres (if the timezone is not specified it is assumed to be UTC). The array with the current bucket might be not yet closed.
 
 `http://<bg_mon.listen_address>:<bg_mon.port>/ui` -- simple web page which fetches statistics from server every second and renders it in a simple html format.

--- a/bg_mon.c
+++ b/bg_mon.c
@@ -85,9 +85,6 @@ static time_t parse_timestamp(const char *uri)
 	time_t ret = -1;
 	const char *str = uri + 1;
 
-	if (*uri != '/')
-		return ret;
-
 	if (strcmp(str, "now") == 0 || strcmp(str, "today") == 0 ||
 		strcmp(str, "tomorrow") == 0 || strcmp(str, "yesterday") == 0)
 		return ret;

--- a/bg_mon.c
+++ b/bg_mon.c
@@ -140,7 +140,8 @@ static bool check_bucket_timerange(time_t tm)
 	struct timeval tv;
 
 	gettimeofday(&tv, NULL);
-	return (tv.tv_sec - tm) / 60 <= bg_mon_num_buckets;
+	tm = tv.tv_sec - tm;
+	return tm > 0 && tm / 60 <= bg_mon_num_buckets;
 }
 
 static time_t parse_bucket_request(const char *uri)

--- a/bg_mon.c
+++ b/bg_mon.c
@@ -18,6 +18,7 @@
 /* these headers are used by this particular worker's code */
 #include "pgstat.h"
 #include "tcop/utility.h"
+#include "utils/datetime.h"
 #include "utils/memutils.h"
 #include "utils/timestamp.h"
 
@@ -79,9 +80,75 @@ static bool accepts_brotli(struct evhttp_request *req)
 	return false;
 }
 
-static int parse_bucket_request(const char *uri)
+static time_t parse_timestamp(const char *uri)
 {
-	int ret = 0;
+	time_t ret = -1;
+	const char *str = uri + 1;
+
+	if (*uri != '/')
+		return ret;
+
+	if (strcmp(str, "now") == 0 || strcmp(str, "today") == 0 ||
+		strcmp(str, "tomorrow") == 0 || strcmp(str, "yesterday") == 0)
+		return ret;
+
+	{
+		fsec_t fsec;
+		struct pg_tm tm = {0,};
+		int tz, dtype, nf;
+		char *field[MAXDATEFIELDS];
+		int ftype[MAXDATEFIELDS];
+		char workbuf[MAXDATELEN + MAXDATEFIELDS];
+		TimestampTz timestamp, current_timestamp;
+
+		size_t size_out;
+		char *decoded = evhttp_uridecode(uri, 1, &size_out);
+
+		if (decoded == NULL)
+			return ret;
+
+		if (ParseDateTime(decoded + 1, workbuf, sizeof(workbuf), field, ftype, MAXDATEFIELDS, &nf) != 0)
+			goto err;
+
+		current_timestamp = GetCurrentTimestamp();
+		if (timestamp2tm(current_timestamp, NULL, &tm, &fsec, NULL, NULL) != 0)
+			goto err;
+
+		if (DecodeDateTime(field, ftype, nf, &dtype, &tm, &fsec, &tz) < 0)
+			goto err;
+
+		if (dtype != DTK_DATE && dtype != DTK_TIME)
+			goto err;
+
+		if (tm2timestamp(&tm, fsec, &tz, &timestamp) != 0)
+			goto err;
+
+		/* when request has only a time in the future off by 1 hour and more consider it as a prev day */
+		if (nf == 1 && ftype[0] == DTK_TIME && (timestamp - current_timestamp) / USECS_PER_HOUR > 0) {
+			j2date(date2j(tm.tm_year, tm.tm_mon, tm.tm_mday) - 1, &tm.tm_year, &tm.tm_mon, &tm.tm_mday);
+
+			if (tm2timestamp(&tm, fsec, &tz, &timestamp) != 0)
+				goto err;
+		}
+
+		ret = timestamptz_to_time_t(timestamp);
+err:
+		free(decoded);
+		return ret;
+	}
+}
+
+static bool check_bucket_timerange(time_t tm)
+{
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+	return (tv.tv_sec - tm) / 60 <= bg_mon_num_buckets;
+}
+
+static time_t parse_bucket_request(const char *uri)
+{
+	time_t ret = 0;
 	const char *p = uri + 1;
 
 	if (*uri != '/')
@@ -89,9 +156,12 @@ static int parse_bucket_request(const char *uri)
 
 	do {
 		if (*p < '0' || *p > '9')
-			return -1;
+			return parse_timestamp(uri);
 		ret = 10 * ret + (*p - '0');
 	} while (*(++p));
+
+	if (ret >= bg_mon_num_buckets && !check_bucket_timerange(ret))
+		return -1;
 
 	return ret;
 }
@@ -102,18 +172,28 @@ static time_t round_minute(time_t time)
 	return time - tm->tm_sec;
 }
 
-static bool send_aggregated_data(struct evhttp_request *req, struct aggregated_stats *agg)
+static bool check_bucket_time(struct aggregated_stats *agg, time_t tm)
+{
+	if (tm)
+		return round_minute(tm) == agg->minute;
+
+	return check_bucket_timerange(agg->minute);
+}
+
+static bool send_aggregated_data(struct evhttp_request *req, struct aggregated_stats *agg, time_t tm)
 {
 	bool ret = false;
 	struct evbuffer *evb;
 
 	pthread_mutex_lock(&agg_lock);
 	if ((ret = agg != NULL)) {
-		if (!agg->state.is_flushed && !agg->state.is_finished)
-			brotli_compress_data(&agg->state, NULL, 0, BROTLI_OPERATION_FLUSH);
+		if (check_bucket_time(agg, tm)) {
+			if (!agg->state.is_flushed && !agg->state.is_finished)
+				brotli_compress_data(&agg->state, NULL, 0, BROTLI_OPERATION_FLUSH);
 
-		evb = evbuffer_new();
-		evbuffer_add(evb, agg->state.to, agg->state.pos);
+			evb = evbuffer_new();
+			evbuffer_add(evb, agg->state.to, agg->state.pos);
+		} else ret = false;
 	}
 	pthread_mutex_unlock(&agg_lock);
 
@@ -125,22 +205,6 @@ static bool send_aggregated_data(struct evhttp_request *req, struct aggregated_s
 		evbuffer_free(evb);
 	}
 	return ret;
-}
-
-static bool send_aggregated_bucket(struct evhttp_request *req, struct aggregated_stats *agg)
-{
-	if (agg == NULL || (time(NULL) - agg->minute)/60 > bg_mon_num_buckets)
-		return false;
-
-	return send_aggregated_data(req, agg);
-}
-
-static bool send_aggregated_bucket_num(struct evhttp_request *req, int bucket)
-{
-	if (bucket < 0 || bucket >= bg_mon_num_buckets)
-		return false;
-
-	return send_aggregated_bucket(req, aggregated + bucket);
 }
 #endif
 
@@ -420,11 +484,17 @@ static void send_document_cb(struct evhttp_request *req, void *arg)
 	const char *uri = evhttp_request_get_uri(req);
 	struct evkeyvalq *output_headers = evhttp_request_get_output_headers(req);
 #ifdef HAS_LIBBROTLI
-	int bucket;
-	if (bg_mon_num_buckets > 0 && (bucket = parse_bucket_request(uri)) > -1)
-		err = !send_aggregated_bucket_num(req, bucket);
-	else if (strcmp(uri, "/prev") == 0)
-		err = !send_aggregated_bucket(req, prev);
+	time_t tm = parse_bucket_request(uri);
+	if (tm > -1) {
+		int bucket;
+		if (tm < bg_mon_num_buckets) {
+			bucket = tm;
+			tm = 0;
+		} else
+			bucket = (tm / 60) % bg_mon_num_buckets;
+		err = !send_aggregated_data(req, aggregated + bucket, tm);
+	} else if (strcmp(uri, "/prev") == 0)
+		err = !send_aggregated_data(req, prev, 0);
 	else
 #endif
 	if (strncmp(uri, "/ui", 3)) {

--- a/test.sh
+++ b/test.sh
@@ -83,7 +83,7 @@ function curl_ps_loop() {
     curl -s http://localhost:$(($bport+$1))/$(date +'%s' -ud '1 hour ago') > /dev/null
     curl -s http://localhost:$(($bport+$1))/$(date | sed 's/ /+/g') > /dev/null
     curl -s http://localhost:$(($bport+$1))/now > /dev/null
-    curl -s http://localhost:$(($bport+$1))/garbadge > /dev/null
+    curl -s http://localhost:$(($bport+$1))/blablabla > /dev/null
 }
 
 function clone_cluster() {

--- a/test.sh
+++ b/test.sh
@@ -84,6 +84,7 @@ function curl_ps_loop() {
     curl -s http://localhost:$(($bport+$1))/$(date | sed 's/ /+/g') > /dev/null
     curl -s http://localhost:$(($bport+$1))/now > /dev/null
     curl -s http://localhost:$(($bport+$1))/blablabla > /dev/null
+    curl -s http://localhost:$(($bport+$1))/100000000000000000000000000000000000000000000 > /dev/null
 }
 
 function clone_cluster() {

--- a/test.sh
+++ b/test.sh
@@ -76,6 +76,12 @@ function curl_ps_loop() {
     for a in $(seq -f '%02g' 0 19); do
         curl -s http://localhost:$(($bport+$1))/$a > /dev/null
     done
+    curl -s http://localhost:$(($bport+$1))/prev > /dev/null
+    curl -s http://localhost:$(($bport+$1))/$(date +'%H:%M' -ud '2 hour') > /dev/null
+    curl -s http://localhost:$(($bport+$1))/$(date +'%H:%M' -ud '1 minute ago') > /dev/null
+    curl -s http://localhost:$(($bport+$1))/$(date +'%s' -ud '1 minute ago') > /dev/null
+    curl -s http://localhost:$(($bport+$1))/$(date +'%s' -ud '1 hour ago') > /dev/null
+    curl -s http://localhost:$(($bport+$1))/$(date | sed 's/ /+/g') > /dev/null
 }
 
 function clone_cluster() {

--- a/test.sh
+++ b/test.sh
@@ -82,6 +82,8 @@ function curl_ps_loop() {
     curl -s http://localhost:$(($bport+$1))/$(date +'%s' -ud '1 minute ago') > /dev/null
     curl -s http://localhost:$(($bport+$1))/$(date +'%s' -ud '1 hour ago') > /dev/null
     curl -s http://localhost:$(($bport+$1))/$(date | sed 's/ /+/g') > /dev/null
+    curl -s http://localhost:$(($bport+$1))/now > /dev/null
+    curl -s http://localhost:$(($bport+$1))/garbadge > /dev/null
 }
 
 function clone_cluster() {


### PR DESCRIPTION
`GET /bucket`

The `bucket` could be:
* bucket id from 0 to N
* unixtime, time, or timestamp in any format supported by postgres

If the timezone is not specified, it is assumed to be UTC.