### PR TITLE
Use realpath func instead of canonicalize_path

### DIFF
--- a/disk_stats.c
+++ b/disk_stats.c
@@ -639,21 +639,21 @@ disk_stats get_disk_stats(void)
 void disk_stats_init(void)
 {
 	pthread_t thread;
-	char tmp_path[MAXPGPATH];
 	List *mounts = read_mounts();
 	size_t datadir_len = strlen(DataDir);
+
+	char buf[PATH_MAX];
+	char tmp_path[MAXPGPATH];
 
 	// we assume wal_directory is always inside DataDir
 	wal_directory = palloc(datadir_len + sizeof(XLOGDIR) + 2);
 	join_path_components(wal_directory, DataDir, XLOGDIR);
 
 	// log_directory can be either inside or outside DataDir
-	log_directory = palloc(datadir_len + strlen(Log_directory) + 2);
 	if (!is_absolute_path(Log_directory))
 		join_path_components(tmp_path, DataDir, Log_directory);
 	else strcpy(tmp_path, Log_directory);
-	if (!realpath(tmp_path, log_directory))
-		strcpy(log_directory, tmp_path);
+	log_directory = realpath(tmp_path, buf) ? pstrdup(buf) : pstrdup(tmp_path);
 
 	data_dev = get_device(mounts, DataDir);
 	if (data_dev) data_dev = pstrdup(data_dev);

--- a/disk_stats.c
+++ b/disk_stats.c
@@ -111,6 +111,7 @@ static void *du_thread(void *arg)
 		// log_directory is a subdirectory of DataDir
 		if (path_is_prefix_of_path(DataDir, log_directory))
 			tmp_data_du -= tmp_log_du;
+
 		pthread_mutex_lock(&du_lock);
 		data_du = tmp_data_du;
 		wal_du = tmp_wal_du;
@@ -638,17 +639,21 @@ disk_stats get_disk_stats(void)
 void disk_stats_init(void)
 {
 	pthread_t thread;
+	char tmp_path[MAXPGPATH];
 	List *mounts = read_mounts();
 	size_t datadir_len = strlen(DataDir);
 
+	// we assume wal_directory is always inside DataDir
 	wal_directory = palloc(datadir_len + sizeof(XLOGDIR) + 2);
 	join_path_components(wal_directory, DataDir, XLOGDIR);
 
+	// log_directory can be either inside or outside DataDir
 	log_directory = palloc(datadir_len + strlen(Log_directory) + 2);
 	if (!is_absolute_path(Log_directory))
-		join_path_components(log_directory, DataDir, Log_directory);
-	else strcpy(log_directory, Log_directory);
-	canonicalize_path(log_directory);
+		join_path_components(tmp_path, DataDir, Log_directory);
+	else strcpy(tmp_path, Log_directory);
+	if (!realpath(tmp_path, log_directory))
+		strcpy(log_directory, tmp_path);
 
 	data_dev = get_device(mounts, DataDir);
 	if (data_dev) data_dev = pstrdup(data_dev);

--- a/disk_stats.c
+++ b/disk_stats.c
@@ -640,13 +640,12 @@ void disk_stats_init(void)
 {
 	pthread_t thread;
 	List *mounts = read_mounts();
-	size_t datadir_len = strlen(DataDir);
 
 	char buf[PATH_MAX];
 	char tmp_path[MAXPGPATH];
 
 	// we assume wal_directory is always inside DataDir
-	wal_directory = palloc(datadir_len + sizeof(XLOGDIR) + 2);
+	wal_directory = palloc(strlen(DataDir) + sizeof(XLOGDIR) + 2);
 	join_path_components(wal_directory, DataDir, XLOGDIR);
 
 	// log_directory can be either inside or outside DataDir


### PR DESCRIPTION
canonicalize_path function was able to remove only trailing '.' and '..' prior to pg15,
thus switch to realpath