### PR TITLE
Compatibility with PG16 beta1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,22 +18,24 @@ jobs:
         - postgres-version: '9.3'
           os: ubuntu-22.04
         - postgres-version: '9.4'
-          os: ubuntu-18.04
-        - postgres-version: '9.5'
           os: ubuntu-20.04
-        - postgres-version: '9.6'
+        - postgres-version: '9.5'
           os: ubuntu-22.04
+        - postgres-version: '9.6'
+          os: ubuntu-20.04
         - postgres-version: '10'
-          os: ubuntu-18.04
+          os: ubuntu-22.04
         - postgres-version: '11'
           os: ubuntu-20.04
         - postgres-version: '12'
           os: ubuntu-22.04
         - postgres-version: '13'
-          os: ubuntu-18.04
-        - postgres-version: '14'
           os: ubuntu-20.04
+        - postgres-version: '14'
+          os: ubuntu-22.04
         - postgres-version: '15'
+          os: ubuntu-20.04
+        - postgres-version: '16'
           os: ubuntu-22.04
 
     steps:

--- a/postgres_stats.h
+++ b/postgres_stats.h
@@ -18,6 +18,7 @@ typedef enum PgBackendType
 	PG_ARCHIVER,
 	PG_STATS_COLLECTOR,
 	PG_LOGGER,
+	PG_STANDALONE_BACKEND,
 	PG_PARALLEL_WORKER,
 	PG_LOGICAL_LAUNCHER,
 	PG_LOGICAL_WORKER
@@ -27,6 +28,7 @@ typedef enum PgBackendType
 #define AUTOVAC_LAUNCHER_PROC_NAME "autovacuum launcher"
 #define AUTOVAC_WORKER_PROC_NAME "autovacuum worker"
 #define BACKEND_PROC_NAME "backend"
+#define STANDALONE_BACKEND_PROC_NAME "standalone backend"
 #define BG_WRITER_NAME "bgwriter"
 #define CHECKPOINTER_PROC_NAME "checkpointer"
 #define STARTUP_PROC_NAME "startup"

--- a/safety_funcs.h
+++ b/safety_funcs.h
@@ -2,6 +2,9 @@
 #define _SAFETY_FUNCS_H_
 
 #include "postgres.h"
+#if PG_VERSION_NUM >= 160000
+#define PG_FUNCNAME_MACRO __func__
+#endif
 
 #define exit_with_error(...) \
 	do { \

--- a/test.sh
+++ b/test.sh
@@ -113,7 +113,7 @@ function clone_cluster() {
 
 create_cluster 0
 
-if [[ $version -ge 13 ]]; then
+if [[ ${version%.*} -ge 13 ]]; then
     # PROCSIG_BARRIER handling test
     psql -h localhost -p $port -d postgres -c "CREATE DATABASE test"
     sleep 1


### PR DESCRIPTION
- new backend type
- DecodeDateTime changed an interface
- fields in PgStat_StatDBEntry were renamed
- PG_FUNCNAME_MACRO was removed
- bg_mon_main() requires PGDLLEXPORT